### PR TITLE
feat(asterisk): set fixed rtp port range

### DIFF
--- a/roles/asterisk/files/rtp.conf
+++ b/roles/asterisk/files/rtp.conf
@@ -1,0 +1,3 @@
+[general]
+rtpstart=30000
+rtpend=40000


### PR DESCRIPTION
The default port range (5000-31000) is too big for my paranoia. Therefore it is best to set a smaller range explicitly through a config file.